### PR TITLE
fix(effort): accept max thinking effort level

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -137,7 +137,7 @@ export function parseModel(value: any): ModelRef | undefined {
   return undefined;
 }
 
-const THINKING_EFFORTS = new Set(['off', 'minimal', 'low', 'medium', 'high', 'xhigh']);
+const THINKING_EFFORTS = new Set(['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
 
 export function parseEffort(value: any): ThinkingEffort | undefined {
   if (!value || value === 'default') return undefined;

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,7 +4,7 @@ export type SubagentMode = 'task' | 'background';
 export type SubagentStatus = 'queued' | 'running' | 'stopping' | 'completed' | 'failed' | 'cancelled' | 'interrupted';
 
 export type ModelRef = { provider: string; id: string };
-export type ThinkingEffort = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh';
+export type ThinkingEffort = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
 
 export type SubagentModelProfile = {
   model?: ModelRef;

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -277,6 +277,7 @@ describe('config and workflow loading', () => {
       model_profiles: {
         analyst: { model: 'anthropic/claude-sonnet-4-5', effort: 'high' },
         reviewer: { model: 'openai/gpt-5.2', effort: 'low' },
+        maxEffort: { model: 'openai/gpt-5.2', effort: 'max' },
         invalidEffort: { model: 'openai/gpt-5.2', effort: 'extreme' },
         invalidModel: { model: 'missing-provider', effort: 'low' },
       },
@@ -293,6 +294,7 @@ describe('config and workflow loading', () => {
     expect(config.model_profiles).toEqual({
       analyst: { model: { provider: 'openai', id: 'gpt-5.2-codex' }, effort: 'medium' },
       reviewer: { model: { provider: 'openai', id: 'gpt-5.2' }, effort: 'low' },
+      maxeffort: { model: { provider: 'openai', id: 'gpt-5.2' }, effort: 'max' },
       invalideffort: { model: { provider: 'openai', id: 'gpt-5.2' } },
       invalidmodel: { effort: 'low' },
       projectonly: { model: { provider: 'anthropic', id: 'claude-opus-4-5' }, effort: 'xhigh' },


### PR DESCRIPTION
### Linked Issue
Closes #9

### PR Type
- [x] Bug fix

### Summary
- `parseEffort` rejected "max" because `THINKING_EFFORTS` and the `ThinkingEffort` type hardcoded the pre-max level set, silently dropping the effort from `subagents.json` profiles.
- "max" is now accepted and passes through to the SDK runner as `thinkingLevel`, matching pi support for the max thinking level since 0.84.
- Added a test case asserting a `max` effort profile is preserved.

### Changes
| File | Change |
|------|--------|
| `src/types.ts` | Add 'max' to the `ThinkingEffort` union |
| `src/config.ts` | Add 'max' to `THINKING_EFFORTS` |
| `test/config.test.ts` | Assert `effort: 'max'` profile loads and is preserved |

### Test Plan
- [x] `npm run typecheck` passes
- [x] `npm test` passes (283 tests, including the new max effort case)

### Contributor Checklist
- [x] Linked issue #9 (repo has no approval gate)
- [x] Added the `bug` label
- [x] Conventional commit format
- [x] No `Co-Authored-By` trailers
