### PR TITLE
Support openrouter models

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -124,9 +124,10 @@ function positiveInteger(value: any, fallback: number): number {
 export function parseModel(value: any): ModelRef | undefined {
   if (!value || value === 'default') return undefined;
   if (typeof value === 'string') {
-    const parts = value.split('/');
-    if (parts.length !== 2) return undefined;
-    const [provider, id] = parts.map((part) => part.trim());
+    const separator = value.indexOf('/');
+    if (separator === -1) return undefined;
+    const provider = value.slice(0, separator).trim();
+    const id = value.slice(separator + 1).trim();
     return provider && id ? { provider, id } : undefined;
   }
   if (isPlainObject(value) && typeof value.provider === 'string' && typeof value.id === 'string') {

--- a/test/config.test.ts
+++ b/test/config.test.ts
@@ -123,6 +123,15 @@ describe('config and workflow loading', () => {
     expect(config.stall_timeout_ms).toBe(10);
   });
 
+  it('parses model ids that contain slashes by splitting on the first separator', () => {
+    fs.writeFileSync(path.join(tmp, '.pi', 'subagents', 'analyst.md'), `---\nname: analyst\ndescription: analyst agent\nmodel: openrouter/stealth/ox-alpha\n---\n# Agent`);
+    fs.writeFileSync(path.join(tmp, '.pi', 'subagents.json'), JSON.stringify({ default_model: 'openrouter/meta-llama/llama-4-scout' }));
+    const agents = loadSubagents(tmp);
+    const config = readSubagentsConfig(tmp);
+    expect(agents[0].model).toEqual({ provider: 'openrouter', id: 'stealth/ox-alpha' });
+    expect(config.default_model).toEqual({ provider: 'openrouter', id: 'meta-llama/llama-4-scout' });
+  });
+
   it('loads default_mode through the global/project config cascade and falls back to task for invalid values', () => {
     const agentDir = path.join(tmp, 'global-agent');
     fs.mkdirSync(agentDir, { recursive: true });


### PR DESCRIPTION
parseModel split the model string on every '/' and required exactly two parts, so ids like openrouter/stealth/ox-alpha were silently rejected and subagents fell back to the default model. Split on the first separator instead so the provider is the first segment and everything after it is the model id.