### PR TITLE
feat(api): expose read-only subagent activity provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ The package manifest exposes:
 
 The npm metadata includes the `pi-package` keyword required for Pi package gallery discovery. After publishing the npm package, it is eligible to appear on the Pi package page.
 
+## Live activity API
+
+After a session starts, another extension can discover the live, read-only provider from the same Pi API object:
+
+```ts
+import { getSubagentActivityProvider } from 'pi-subagents-j0k3r';
+
+const provider = getSubagentActivityProvider(pi);
+const unsubscribe = provider?.subscribe((snapshot) => {
+  // snapshot.tasks contains safe identity, lifecycle, profile, usage, and activity data.
+});
+```
+
+The provider is versioned (`version: 1`), sends a complete immutable snapshot synchronously on subscription, and reports ordered process-local revisions. It is backed by the extension's current `SubagentManager`; it does not replay SQLite history or expose controls, prompts, arguments, paths, output, transcripts, or errors. Reloading the extension replaces the registration and cleans up the previous provider's manager listener.
+
 Use `/reload` after changing extension code, skill files, config, or markdown subagent definitions during an interactive session.
 
 Package installation scope and configuration scope are independent. A globally installed extension can still use project-local `.pi/subagents.json` and `.pi/subagents/*.md`; a project-local package installation does not require every subagent setting to be project-local.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ The npm metadata includes the `pi-package` keyword required for Pi package galle
 
 ## Live activity API
 
-Another extension can watch the live, read-only provider on the same Pi API object, including when it registers after the consumer:
+Another extension can watch the live, read-only provider. Same-module consumers may use the root APIs directly; distinct ExtensionAPI proxies use Pi's shared `pi.events` bus:
 
 ```ts
 import { watchSubagentActivityProvider } from 'pi-subagents-j0k3r';
@@ -78,7 +78,7 @@ const unsubscribeDiscovery = watchSubagentActivityProvider(pi, (provider) => {
 });
 ```
 
-The watcher calls back synchronously with the current provider (or `undefined`), then on registration, replacement, and disposal. The provider is versioned (`version: 1`), sends a complete immutable snapshot synchronously on subscription, and reports ordered process-local revisions. It is backed by the extension's current `SubagentManager`; it does not replay SQLite history or expose controls, prompts, arguments, paths, output, transcripts, or errors. Reloading the extension replaces the registration and cleans up the previous provider's manager listener.
+The watcher first reports the current provider (or `undefined`), then reports registration, replacement, disposal, and shutdown. The exported `SUBAGENT_ACTIVITY_PROVIDER_REQUEST_CHANNEL` and `SUBAGENT_ACTIVITY_PROVIDER_CHANGED_CHANNEL` are versioned (`v1`): consumers emit a request; the provider replies or publishes only a provider object (or `undefined`). Load order is safe—consumer-first receives later registration, provider-first receives a request response—and unsubscribe/reload removes listeners without duplicate delivery. Provider snapshots are versioned (`version: 1`), complete, immutable, and process-local; task data stays inside snapshots, which expose safe identity, lifecycle, profile, usage, and activity only—not controls, prompts, arguments, paths, output, transcripts, or errors. Reloading cleans the previous manager watcher.
 
 Use `/reload` after changing extension code, skill files, config, or markdown subagent definitions during an interactive session.
 

--- a/README.md
+++ b/README.md
@@ -64,18 +64,21 @@ The npm metadata includes the `pi-package` keyword required for Pi package galle
 
 ## Live activity API
 
-After a session starts, another extension can discover the live, read-only provider from the same Pi API object:
+Another extension can watch the live, read-only provider on the same Pi API object, including when it registers after the consumer:
 
 ```ts
-import { getSubagentActivityProvider } from 'pi-subagents-j0k3r';
+import { watchSubagentActivityProvider } from 'pi-subagents-j0k3r';
 
-const provider = getSubagentActivityProvider(pi);
-const unsubscribe = provider?.subscribe((snapshot) => {
-  // snapshot.tasks contains safe identity, lifecycle, profile, usage, and activity data.
+let unsubscribeActivity = () => {};
+const unsubscribeDiscovery = watchSubagentActivityProvider(pi, (provider) => {
+  unsubscribeActivity();
+  unsubscribeActivity = provider?.subscribe((snapshot) => {
+    // snapshot.tasks contains safe identity, lifecycle, profile, usage, and activity data.
+  }) ?? (() => {});
 });
 ```
 
-The provider is versioned (`version: 1`), sends a complete immutable snapshot synchronously on subscription, and reports ordered process-local revisions. It is backed by the extension's current `SubagentManager`; it does not replay SQLite history or expose controls, prompts, arguments, paths, output, transcripts, or errors. Reloading the extension replaces the registration and cleans up the previous provider's manager listener.
+The watcher calls back synchronously with the current provider (or `undefined`), then on registration, replacement, and disposal. The provider is versioned (`version: 1`), sends a complete immutable snapshot synchronously on subscription, and reports ordered process-local revisions. It is backed by the extension's current `SubagentManager`; it does not replay SQLite history or expose controls, prompts, arguments, paths, output, transcripts, or errors. Reloading the extension replaces the registration and cleans up the previous provider's manager listener.
 
 Use `/reload` after changing extension code, skill files, config, or markdown subagent definitions during an interactive session.
 

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,6 @@ export { createSubagentsPanelKeyMatcher } from './src/ui/panel-input.js';
 export { resolveRegisteredToolDefinition } from './src/ui/panel-overlay.js';
 export { ClaudeBackgroundWidget, ClaudeBackgroundWidgetState, moveClaudeBackgroundWidgetSelection, renderClaudeBackgroundWidgetLines } from './src/ui/background-widget.js';
 export { completionMessage, renderSubagentCompletionMessage, sendSubagentCompletionMessage } from './src/render/completion-message.js';
-export { getSubagentActivityProvider, SUBAGENT_ACTIVITY_PROVIDER_VERSION, watchSubagentActivityProvider } from './src/activity-provider.js';
+export { getSubagentActivityProvider, SUBAGENT_ACTIVITY_PROVIDER_CHANGED_CHANNEL, SUBAGENT_ACTIVITY_PROVIDER_REQUEST_CHANNEL, SUBAGENT_ACTIVITY_PROVIDER_VERSION, watchSubagentActivityProvider } from './src/activity-provider.js';
 export type { SubagentActivity, SubagentActivityEffort, SubagentActivityKind, SubagentActivityMode, SubagentActivityProfileSource, SubagentActivityProvider, SubagentActivitySnapshot, SubagentActivityStatus, SubagentActivityTask, SubagentActivityUsage } from './src/activity-provider.js';
 export { default } from './src/extension/subagents-extension.js';

--- a/index.ts
+++ b/index.ts
@@ -2,4 +2,6 @@ export { createSubagentsPanelKeyMatcher } from './src/ui/panel-input.js';
 export { resolveRegisteredToolDefinition } from './src/ui/panel-overlay.js';
 export { ClaudeBackgroundWidget, ClaudeBackgroundWidgetState, moveClaudeBackgroundWidgetSelection, renderClaudeBackgroundWidgetLines } from './src/ui/background-widget.js';
 export { completionMessage, renderSubagentCompletionMessage, sendSubagentCompletionMessage } from './src/render/completion-message.js';
+export { getSubagentActivityProvider, SUBAGENT_ACTIVITY_PROVIDER_VERSION } from './src/activity-provider.js';
+export type { SubagentActivity, SubagentActivityEffort, SubagentActivityKind, SubagentActivityMode, SubagentActivityProfileSource, SubagentActivityProvider, SubagentActivitySnapshot, SubagentActivityStatus, SubagentActivityTask, SubagentActivityUsage } from './src/activity-provider.js';
 export { default } from './src/extension/subagents-extension.js';

--- a/index.ts
+++ b/index.ts
@@ -2,6 +2,6 @@ export { createSubagentsPanelKeyMatcher } from './src/ui/panel-input.js';
 export { resolveRegisteredToolDefinition } from './src/ui/panel-overlay.js';
 export { ClaudeBackgroundWidget, ClaudeBackgroundWidgetState, moveClaudeBackgroundWidgetSelection, renderClaudeBackgroundWidgetLines } from './src/ui/background-widget.js';
 export { completionMessage, renderSubagentCompletionMessage, sendSubagentCompletionMessage } from './src/render/completion-message.js';
-export { getSubagentActivityProvider, SUBAGENT_ACTIVITY_PROVIDER_VERSION } from './src/activity-provider.js';
+export { getSubagentActivityProvider, SUBAGENT_ACTIVITY_PROVIDER_VERSION, watchSubagentActivityProvider } from './src/activity-provider.js';
 export type { SubagentActivity, SubagentActivityEffort, SubagentActivityKind, SubagentActivityMode, SubagentActivityProfileSource, SubagentActivityProvider, SubagentActivitySnapshot, SubagentActivityStatus, SubagentActivityTask, SubagentActivityUsage } from './src/activity-provider.js';
 export { default } from './src/extension/subagents-extension.js';

--- a/src/activity-provider.ts
+++ b/src/activity-provider.ts
@@ -1,6 +1,8 @@
 import type { SubagentTask } from './types.js';
 
 export const SUBAGENT_ACTIVITY_PROVIDER_VERSION = 1 as const;
+export const SUBAGENT_ACTIVITY_PROVIDER_REQUEST_CHANNEL = 'pi-subagents-j0k3r:activity-provider-request:v1' as const;
+export const SUBAGENT_ACTIVITY_PROVIDER_CHANGED_CHANNEL = 'pi-subagents-j0k3r:activity-provider-changed:v1' as const;
 export type SubagentActivityStatus = 'queued' | 'running' | 'stopping' | 'completed' | 'failed' | 'cancelled' | 'interrupted';
 export type SubagentActivityMode = 'task' | 'background';
 export type SubagentActivityKind = 'thinking' | 'streaming_response' | 'tool_running' | 'tool_completed' | 'tool_failed';
@@ -25,9 +27,11 @@ type SubagentManagerActivitySource = {
 type ProviderWatcher = (provider: SubagentActivityProvider | undefined) => void;
 type Registration = { provider: SubagentActivityProvider; dispose: (notify?: boolean) => void };
 type Discovery = { provider?: SubagentActivityProvider; listeners: Set<ProviderWatcher>; notifying: boolean };
+type EventBus = { on(channel: string, handler: (data: unknown) => void): () => void; emit(channel: string, data: unknown): void };
 type PiHost = Record<PropertyKey, unknown>;
 const REGISTRATION_KEY = Symbol.for('pi-subagents-j0k3r.activity-provider.v1');
 const DISCOVERY_KEY = Symbol.for('pi-subagents-j0k3r.activity-provider-discovery.v1');
+const PROVIDER_EVENT_UNSUBSCRIBERS = new WeakMap<EventBus, () => void>();
 const STATUSES = new Set<SubagentActivityStatus>(['queued', 'running', 'stopping', 'completed', 'failed', 'cancelled', 'interrupted']);
 const MODES = new Set<SubagentActivityMode>(['task', 'background']);
 const KINDS = new Set<SubagentActivityKind>(['thinking', 'streaming_response', 'tool_running', 'tool_completed', 'tool_failed']);
@@ -37,6 +41,13 @@ const TERMINAL = new Set<SubagentActivityStatus>(['completed', 'failed', 'cancel
 const USAGE_FIELDS = ['input', 'output', 'cacheRead', 'cacheWrite', 'cost', 'contextTokens', 'turns'] as const;
 
 function hostFor(pi: unknown): PiHost | undefined { return pi && (typeof pi === 'object' || typeof pi === 'function') ? pi as PiHost : undefined; }
+function eventBusFor(host: PiHost): EventBus | undefined { const events = host.events as EventBus | undefined; return events && typeof events.on === 'function' && typeof events.emit === 'function' ? events : undefined; }
+function publishProvider(host: PiHost, provider: SubagentActivityProvider | undefined): void { eventBusFor(host)?.emit(SUBAGENT_ACTIVITY_PROVIDER_CHANGED_CHANNEL, provider); }
+export function installSubagentActivityProviderTransport(pi: unknown): void {
+  const host = hostFor(pi); const events = host && eventBusFor(host); if (!host || !events) return;
+  PROVIDER_EVENT_UNSUBSCRIBERS.get(events)?.();
+  PROVIDER_EVENT_UNSUBSCRIBERS.set(events, events.on(SUBAGENT_ACTIVITY_PROVIDER_REQUEST_CHANNEL, () => events.emit(SUBAGENT_ACTIVITY_PROVIDER_CHANGED_CHANNEL, getSubagentActivityProvider(host))));
+}
 function safeText(value: unknown, limit: number): string | undefined { return typeof value === 'string' && value.length > 0 && value.length <= limit && !/[\u0000-\u001f\u007f]/.test(value) ? value : undefined; }
 function safeToken(value: unknown, limit: number): string | undefined { const text = safeText(value, limit); return text && /^[A-Za-z0-9][A-Za-z0-9_.:-]*$/.test(text) ? text : undefined; }
 function safeTimestamp(value: unknown): string | undefined { const text = safeText(value, 64); return text && Number.isFinite(Date.parse(text)) ? text : undefined; }
@@ -112,16 +123,17 @@ function notifyDiscovery(host: PiHost, provider: SubagentActivityProvider | unde
 function disposeRegistration(host: PiHost, notify: boolean): void { (host[REGISTRATION_KEY] as Registration | undefined)?.dispose(notify); }
 
 export function disposeSubagentActivityProvider(pi: unknown): void { const host = hostFor(pi); if (host) disposeRegistration(host, true); }
-export function registerSubagentActivityProvider(pi: unknown, manager: SubagentManagerActivitySource, scope: SubagentActivityScope): (() => void) | undefined {
-  const host = hostFor(pi); if (!host) return undefined; disposeRegistration(host, false);
-  if (!scope || typeof scope.cwd !== 'string' || !scope.cwd || typeof scope.sessionId !== 'string' || !scope.sessionId || typeof manager?.listLiveTasks !== 'function' || typeof manager?.subscribeTaskUpdates !== 'function') { notifyDiscovery(host, undefined); return undefined; }
+export function registerSubagentActivityProvider(pi: unknown, manager: SubagentManagerActivitySource, scope: SubagentActivityScope): ((notify?: boolean) => void) | undefined {
+  const host = hostFor(pi); if (!host) return undefined; const hadProvider = Boolean(host[REGISTRATION_KEY]); disposeRegistration(host, false);
+  if (!scope || typeof scope.cwd !== 'string' || !scope.cwd || typeof scope.sessionId !== 'string' || !scope.sessionId || typeof manager?.listLiveTasks !== 'function' || typeof manager?.subscribeTaskUpdates !== 'function') { notifyDiscovery(host, undefined); if (hadProvider) publishProvider(host, undefined); return undefined; }
   const created = createProvider(manager, scope); let registration: Registration;
-  const dispose = (notify = true) => { created.dispose(); if (host[REGISTRATION_KEY] === registration) { delete host[REGISTRATION_KEY]; if (notify) notifyDiscovery(host, undefined); } };
-  registration = { provider: created.provider, dispose }; Object.defineProperty(host, REGISTRATION_KEY, { configurable: true, enumerable: false, value: registration, writable: true }); notifyDiscovery(host, created.provider); return dispose;
+  const dispose = (notify = true) => { created.dispose(); if (host[REGISTRATION_KEY] === registration) { delete host[REGISTRATION_KEY]; if (notify) { notifyDiscovery(host, undefined); publishProvider(host, undefined); } } };
+  registration = { provider: created.provider, dispose }; Object.defineProperty(host, REGISTRATION_KEY, { configurable: true, enumerable: false, value: registration, writable: true }); notifyDiscovery(host, created.provider); publishProvider(host, created.provider); return dispose;
 }
 export function getSubagentActivityProvider(pi: unknown): SubagentActivityProvider | undefined { return (hostFor(pi)?.[REGISTRATION_KEY] as Registration | undefined)?.provider; }
 export function watchSubagentActivityProvider(pi: unknown, listener: ProviderWatcher): (() => void) | undefined {
-  const host = hostFor(pi); if (!host || typeof listener !== 'function') return undefined; const discovery = discoveryFor(host); let subscribed = true; discovery.listeners.add(listener);
-  try { listener(discovery.provider); } catch { /* discovery observers must not break subscription */ }
-  return () => { if (!subscribed) return; subscribed = false; discovery.listeners.delete(listener); if (!discovery.listeners.size && host[DISCOVERY_KEY] === discovery) delete host[DISCOVERY_KEY]; };
+  const host = hostFor(pi); if (!host || typeof listener !== 'function') return undefined; const discovery = discoveryFor(host); let subscribed = true; let seen = false; let current: SubagentActivityProvider | undefined;
+  const notify = (provider: SubagentActivityProvider | undefined) => { if (seen && current === provider) return; seen = true; current = provider; try { listener(provider); } catch { /* discovery observers must not break subscription */ } };
+  discovery.listeners.add(notify); const events = eventBusFor(host); const stopEvents = events?.on(SUBAGENT_ACTIVITY_PROVIDER_CHANGED_CHANNEL, (provider) => notify(provider as SubagentActivityProvider | undefined)); notify(discovery.provider); events?.emit(SUBAGENT_ACTIVITY_PROVIDER_REQUEST_CHANNEL, undefined);
+  return () => { if (!subscribed) return; subscribed = false; discovery.listeners.delete(notify); stopEvents?.(); if (!discovery.listeners.size && host[DISCOVERY_KEY] === discovery) delete host[DISCOVERY_KEY]; };
 }

--- a/src/activity-provider.ts
+++ b/src/activity-provider.ts
@@ -1,0 +1,95 @@
+import type { SubagentTask } from './types.js';
+
+export const SUBAGENT_ACTIVITY_PROVIDER_VERSION = 1 as const;
+export type SubagentActivityStatus = 'queued' | 'running' | 'stopping' | 'completed' | 'failed' | 'cancelled' | 'interrupted';
+export type SubagentActivityMode = 'task' | 'background';
+export type SubagentActivityKind = 'thinking' | 'streaming_response' | 'tool_running' | 'tool_completed' | 'tool_failed';
+export type SubagentActivityProfileSource = 'profile' | 'definition' | 'default' | 'orchestrator' | 'unresolved';
+export type SubagentActivityEffort = 'off' | 'minimal' | 'low' | 'medium' | 'high' | 'xhigh' | 'max';
+export type SubagentActivityUsage = Readonly<Partial<{ input: number; output: number; cacheRead: number; cacheWrite: number; cost: number; contextTokens: number; turns: number }>>;
+export type SubagentActivity = Readonly<{ kind: SubagentActivityKind; tool_names?: readonly string[] }>;
+export type SubagentActivityTask = Readonly<{
+  id: string; agent: string; mode: SubagentActivityMode; status: SubagentActivityStatus;
+  created_at?: string; started_at?: string; ended_at?: string; last_activity_at?: string;
+  model?: string; effort?: SubagentActivityEffort; model_source?: SubagentActivityProfileSource; effort_source?: SubagentActivityProfileSource;
+  usage?: SubagentActivityUsage; activity?: SubagentActivity;
+}>;
+export type SubagentActivitySnapshot = Readonly<{ version: typeof SUBAGENT_ACTIVITY_PROVIDER_VERSION; revision: number; tasks: readonly SubagentActivityTask[] }>;
+export type SubagentActivityProvider = Readonly<{ version: typeof SUBAGENT_ACTIVITY_PROVIDER_VERSION; getSnapshot(): SubagentActivitySnapshot; subscribe(listener: (snapshot: SubagentActivitySnapshot) => void): () => void }>;
+export type SubagentActivityScope = Readonly<{ cwd: string; sessionId: string }>;
+
+type SubagentManagerActivitySource = {
+  listLiveTasks(cwd: string, sessionId: string): readonly SubagentTask[];
+  subscribeTaskUpdates(listener: (task: SubagentTask) => void): () => void;
+};
+type Registration = { provider: SubagentActivityProvider; dispose: () => void };
+type PiHost = Record<PropertyKey, unknown>;
+const REGISTRATION_KEY = Symbol.for('pi-subagents-j0k3r.activity-provider.v1');
+const STATUSES = new Set<SubagentActivityStatus>(['queued', 'running', 'stopping', 'completed', 'failed', 'cancelled', 'interrupted']);
+const MODES = new Set<SubagentActivityMode>(['task', 'background']);
+const KINDS = new Set<SubagentActivityKind>(['thinking', 'streaming_response', 'tool_running', 'tool_completed', 'tool_failed']);
+const SOURCES = new Set<SubagentActivityProfileSource>(['profile', 'definition', 'default', 'orchestrator', 'unresolved']);
+const EFFORTS = new Set<SubagentActivityEffort>(['off', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max']);
+const TERMINAL = new Set<SubagentActivityStatus>(['completed', 'failed', 'cancelled', 'interrupted']);
+const USAGE_FIELDS = ['input', 'output', 'cacheRead', 'cacheWrite', 'cost', 'contextTokens', 'turns'] as const;
+
+function hostFor(pi: unknown): PiHost | undefined { return pi && (typeof pi === 'object' || typeof pi === 'function') ? pi as PiHost : undefined; }
+function safeText(value: unknown, limit: number): string | undefined { return typeof value === 'string' && value.length > 0 && value.length <= limit && !/[\u0000-\u001f\u007f]/.test(value) ? value : undefined; }
+function safeToken(value: unknown, limit: number): string | undefined { const text = safeText(value, limit); return text && /^[A-Za-z0-9][A-Za-z0-9_.:-]*$/.test(text) ? text : undefined; }
+function safeTimestamp(value: unknown): string | undefined { const text = safeText(value, 64); return text && Number.isFinite(Date.parse(text)) ? text : undefined; }
+function safeModel(value: unknown): string | undefined { const text = safeText(value, 256); return text && /^[A-Za-z0-9][A-Za-z0-9_.:/-]*$/.test(text) ? text : undefined; }
+function copyUsage(value: unknown): SubagentActivityUsage | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const result: Record<string, number> = {};
+  for (const field of USAGE_FIELDS) { const candidate = (value as Record<string, unknown>)[field]; if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate >= 0) result[field] = candidate; }
+  return Object.keys(result).length ? result as SubagentActivityUsage : undefined;
+}
+function copyActivity(value: unknown): SubagentActivity | undefined {
+  if (!value || typeof value !== 'object') return undefined;
+  const current = (value as { current?: unknown }).current;
+  if (!current || typeof current !== 'object') return undefined;
+  const kind = (current as { kind?: unknown }).kind as SubagentActivityKind;
+  if (!KINDS.has(kind)) return undefined;
+  const rawNames = (current as { tool_names?: unknown }).tool_names;
+  const names = Array.isArray(rawNames) ? [...new Set(rawNames.map((name) => safeToken(name, 64)).filter((name): name is string => Boolean(name)))].slice(0, 8) : [];
+  return names.length ? { kind, tool_names: names } : { kind };
+}
+function projectTask(task: SubagentTask): SubagentActivityTask | undefined {
+  if (!STATUSES.has(task.status as SubagentActivityStatus) || !MODES.has(task.mode as SubagentActivityMode)) return undefined;
+  const id = safeToken(task.id, 160); const agent = safeToken(task.agent, 128); if (!id || !agent) return undefined;
+  const result: Record<string, unknown> = { id, agent, mode: task.mode, status: task.status };
+  for (const [key, value] of [['created_at', task.created_at], ['started_at', task.started_at], ['ended_at', task.ended_at], ['last_activity_at', task.last_activity_at]] as const) { const date = safeTimestamp(value); if (date) result[key] = date; }
+  const model = safeModel(task.model); if (model) result.model = model;
+  if (EFFORTS.has(task.effort as SubagentActivityEffort)) result.effort = task.effort;
+  if (SOURCES.has(task.model_source as SubagentActivityProfileSource)) result.model_source = task.model_source;
+  if (SOURCES.has(task.effort_source as SubagentActivityProfileSource)) result.effort_source = task.effort_source;
+  const usage = copyUsage(task.usage); if (usage) result.usage = usage;
+  if (!TERMINAL.has(task.status as SubagentActivityStatus)) { const activity = copyActivity(task.live_activity); if (activity) result.activity = activity; }
+  return result as SubagentActivityTask;
+}
+function freeze<T>(value: T): T { if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value; for (const child of Object.values(value as Record<string, unknown>)) freeze(child); return Object.freeze(value); }
+function makeSnapshot(manager: SubagentManagerActivitySource, scope: SubagentActivityScope, revision: number): SubagentActivitySnapshot { return freeze({ version: SUBAGENT_ACTIVITY_PROVIDER_VERSION, revision, tasks: manager.listLiveTasks(scope.cwd, scope.sessionId).map(projectTask).filter((task): task is SubagentActivityTask => Boolean(task)) }); }
+function sameSnapshot(left: SubagentActivitySnapshot, right: SubagentActivitySnapshot): boolean { return left.version === right.version && JSON.stringify(left.tasks) === JSON.stringify(right.tasks); }
+function createProvider(manager: SubagentManagerActivitySource, scope: SubagentActivityScope): Registration {
+  let active = true; let revision = 0; let current = makeSnapshot(manager, scope, revision); const listeners = new Set<(snapshot: SubagentActivitySnapshot) => void>();
+  const onManagerUpdate = () => {
+    if (!active) return; const next = makeSnapshot(manager, scope, revision + 1); if (sameSnapshot(current, next)) return;
+    revision += 1; current = next; for (const listener of [...listeners]) { try { listener(current); } catch { /* observers must not break delegation */ } }
+  };
+  const unsubscribeManager = manager.subscribeTaskUpdates(onManagerUpdate);
+  const provider: SubagentActivityProvider = Object.freeze({
+    version: SUBAGENT_ACTIVITY_PROVIDER_VERSION, getSnapshot: () => current,
+    subscribe(listener) { if (!active) return () => undefined; let subscribed = true; listeners.add(listener); try { listener(current); } catch { /* keep subscription lifecycle deterministic */ } return () => { if (subscribed) { subscribed = false; listeners.delete(listener); } }; },
+  });
+  return { provider, dispose: () => { if (active) { active = false; listeners.clear(); unsubscribeManager(); } } };
+}
+
+export function disposeSubagentActivityProvider(pi: unknown): void { (hostFor(pi)?.[REGISTRATION_KEY] as Registration | undefined)?.dispose(); }
+export function registerSubagentActivityProvider(pi: unknown, manager: SubagentManagerActivitySource, scope: SubagentActivityScope): (() => void) | undefined {
+  const host = hostFor(pi); if (!host) return undefined; disposeSubagentActivityProvider(host);
+  if (!scope || typeof scope.cwd !== 'string' || !scope.cwd || typeof scope.sessionId !== 'string' || !scope.sessionId || typeof manager?.listLiveTasks !== 'function' || typeof manager?.subscribeTaskUpdates !== 'function') return undefined;
+  const created = createProvider(manager, scope); let registration: Registration;
+  const dispose = () => { created.dispose(); if (host[REGISTRATION_KEY] === registration) delete host[REGISTRATION_KEY]; };
+  registration = { provider: created.provider, dispose }; Object.defineProperty(host, REGISTRATION_KEY, { configurable: true, enumerable: false, value: registration, writable: true }); return dispose;
+}
+export function getSubagentActivityProvider(pi: unknown): SubagentActivityProvider | undefined { return (hostFor(pi)?.[REGISTRATION_KEY] as Registration | undefined)?.provider; }

--- a/src/activity-provider.ts
+++ b/src/activity-provider.ts
@@ -22,9 +22,12 @@ type SubagentManagerActivitySource = {
   listLiveTasks(cwd: string, sessionId: string): readonly SubagentTask[];
   subscribeTaskUpdates(listener: (task: SubagentTask) => void): () => void;
 };
-type Registration = { provider: SubagentActivityProvider; dispose: () => void };
+type ProviderWatcher = (provider: SubagentActivityProvider | undefined) => void;
+type Registration = { provider: SubagentActivityProvider; dispose: (notify?: boolean) => void };
+type Discovery = { provider?: SubagentActivityProvider; listeners: Set<ProviderWatcher>; notifying: boolean };
 type PiHost = Record<PropertyKey, unknown>;
 const REGISTRATION_KEY = Symbol.for('pi-subagents-j0k3r.activity-provider.v1');
+const DISCOVERY_KEY = Symbol.for('pi-subagents-j0k3r.activity-provider-discovery.v1');
 const STATUSES = new Set<SubagentActivityStatus>(['queued', 'running', 'stopping', 'completed', 'failed', 'cancelled', 'interrupted']);
 const MODES = new Set<SubagentActivityMode>(['task', 'background']);
 const KINDS = new Set<SubagentActivityKind>(['thinking', 'streaming_response', 'tool_running', 'tool_completed', 'tool_failed']);
@@ -84,12 +87,41 @@ function createProvider(manager: SubagentManagerActivitySource, scope: SubagentA
   return { provider, dispose: () => { if (active) { active = false; listeners.clear(); unsubscribeManager(); } } };
 }
 
-export function disposeSubagentActivityProvider(pi: unknown): void { (hostFor(pi)?.[REGISTRATION_KEY] as Registration | undefined)?.dispose(); }
+function discoveryFor(host: PiHost): Discovery {
+  const existing = host[DISCOVERY_KEY] as Discovery | undefined; if (existing) return existing;
+  const registration = host[REGISTRATION_KEY] as Registration | undefined;
+  const discovery = { provider: registration?.provider, listeners: new Set<ProviderWatcher>(), notifying: false };
+  Object.defineProperty(host, DISCOVERY_KEY, { configurable: true, enumerable: false, value: discovery, writable: true }); return discovery;
+}
+function notifyDiscovery(host: PiHost, provider: SubagentActivityProvider | undefined): void {
+  const discovery = host[DISCOVERY_KEY] as Discovery | undefined; if (!discovery || discovery.provider === provider) return;
+  discovery.provider = provider; if (discovery.notifying) return; discovery.notifying = true;
+  try {
+    while (true) {
+      const current = discovery.provider; let changed = false;
+      for (const listener of [...discovery.listeners]) {
+        if (!discovery.listeners.has(listener)) continue;
+        if (discovery.provider !== current) { changed = true; break; }
+        try { listener(current); } catch { /* discovery observers must not break registration */ }
+        if (discovery.provider !== current) { changed = true; break; }
+      }
+      if (!changed && discovery.provider === current) break;
+    }
+  } finally { discovery.notifying = false; }
+}
+function disposeRegistration(host: PiHost, notify: boolean): void { (host[REGISTRATION_KEY] as Registration | undefined)?.dispose(notify); }
+
+export function disposeSubagentActivityProvider(pi: unknown): void { const host = hostFor(pi); if (host) disposeRegistration(host, true); }
 export function registerSubagentActivityProvider(pi: unknown, manager: SubagentManagerActivitySource, scope: SubagentActivityScope): (() => void) | undefined {
-  const host = hostFor(pi); if (!host) return undefined; disposeSubagentActivityProvider(host);
-  if (!scope || typeof scope.cwd !== 'string' || !scope.cwd || typeof scope.sessionId !== 'string' || !scope.sessionId || typeof manager?.listLiveTasks !== 'function' || typeof manager?.subscribeTaskUpdates !== 'function') return undefined;
+  const host = hostFor(pi); if (!host) return undefined; disposeRegistration(host, false);
+  if (!scope || typeof scope.cwd !== 'string' || !scope.cwd || typeof scope.sessionId !== 'string' || !scope.sessionId || typeof manager?.listLiveTasks !== 'function' || typeof manager?.subscribeTaskUpdates !== 'function') { notifyDiscovery(host, undefined); return undefined; }
   const created = createProvider(manager, scope); let registration: Registration;
-  const dispose = () => { created.dispose(); if (host[REGISTRATION_KEY] === registration) delete host[REGISTRATION_KEY]; };
-  registration = { provider: created.provider, dispose }; Object.defineProperty(host, REGISTRATION_KEY, { configurable: true, enumerable: false, value: registration, writable: true }); return dispose;
+  const dispose = (notify = true) => { created.dispose(); if (host[REGISTRATION_KEY] === registration) { delete host[REGISTRATION_KEY]; if (notify) notifyDiscovery(host, undefined); } };
+  registration = { provider: created.provider, dispose }; Object.defineProperty(host, REGISTRATION_KEY, { configurable: true, enumerable: false, value: registration, writable: true }); notifyDiscovery(host, created.provider); return dispose;
 }
 export function getSubagentActivityProvider(pi: unknown): SubagentActivityProvider | undefined { return (hostFor(pi)?.[REGISTRATION_KEY] as Registration | undefined)?.provider; }
+export function watchSubagentActivityProvider(pi: unknown, listener: ProviderWatcher): (() => void) | undefined {
+  const host = hostFor(pi); if (!host || typeof listener !== 'function') return undefined; const discovery = discoveryFor(host); let subscribed = true; discovery.listeners.add(listener);
+  try { listener(discovery.provider); } catch { /* discovery observers must not break subscription */ }
+  return () => { if (!subscribed) return; subscribed = false; discovery.listeners.delete(listener); if (!discovery.listeners.size && host[DISCOVERY_KEY] === discovery) delete host[DISCOVERY_KEY]; };
+}

--- a/src/extension/subagents-extension.ts
+++ b/src/extension/subagents-extension.ts
@@ -1,5 +1,5 @@
 import { readSubagentsConfig, subagentSourceWarnings } from '../config.js';
-import { disposeSubagentActivityProvider, registerSubagentActivityProvider } from '../activity-provider.js';
+import { disposeSubagentActivityProvider, installSubagentActivityProviderTransport, registerSubagentActivityProvider } from '../activity-provider.js';
 import { SubagentManager } from '../manager.js';
 import { runSubagentModelsCommand } from '../model-profiles-ui.js';
 import { renderSubagentCompletionMessage, sendSubagentCompletionMessage } from '../render/completion-message.js';
@@ -20,10 +20,11 @@ export default function subagentsExtension(pi: any): void {
     sendSubagentCompletionMessage(pi, task, cwd);
   });
   disposeSubagentActivityProvider(pi);
+  installSubagentActivityProviderTransport(pi);
   registerSubagentTools(pi, manager, process.cwd());
 
-  let disposeActivityProvider: (() => void) | undefined;
-  const clearActivityProvider = () => { disposeActivityProvider?.(); disposeActivityProvider = undefined; };
+  let disposeActivityProvider: ((notify?: boolean) => void) | undefined;
+  const clearActivityProvider = (notify = true) => { disposeActivityProvider?.(notify); disposeActivityProvider = undefined; };
   let widgetTimer: NodeJS.Timeout | undefined;
   let widgetCtx: any;
   let widgetRequestRender: (() => void) | undefined;
@@ -78,7 +79,7 @@ export default function subagentsExtension(pi: any): void {
 
   pi.on?.('session_start', (_event: unknown, ctx: any) => {
     clearClaudeBackgroundWidget();
-    clearActivityProvider();
+    clearActivityProvider(false);
     const cwd = ctx?.cwd ?? process.cwd();
     const sessionId = currentSessionId(ctx);
     manager.reconcileOrphanedTasks(cwd);

--- a/src/extension/subagents-extension.ts
+++ b/src/extension/subagents-extension.ts
@@ -1,4 +1,5 @@
 import { readSubagentsConfig, subagentSourceWarnings } from '../config.js';
+import { disposeSubagentActivityProvider, registerSubagentActivityProvider } from '../activity-provider.js';
 import { SubagentManager } from '../manager.js';
 import { runSubagentModelsCommand } from '../model-profiles-ui.js';
 import { renderSubagentCompletionMessage, sendSubagentCompletionMessage } from '../render/completion-message.js';
@@ -18,8 +19,11 @@ export default function subagentsExtension(pi: any): void {
   const manager = new SubagentManager(undefined, undefined, (task, cwd) => {
     sendSubagentCompletionMessage(pi, task, cwd);
   });
+  disposeSubagentActivityProvider(pi);
   registerSubagentTools(pi, manager, process.cwd());
 
+  let disposeActivityProvider: (() => void) | undefined;
+  const clearActivityProvider = () => { disposeActivityProvider?.(); disposeActivityProvider = undefined; };
   let widgetTimer: NodeJS.Timeout | undefined;
   let widgetCtx: any;
   let widgetRequestRender: (() => void) | undefined;
@@ -74,8 +78,11 @@ export default function subagentsExtension(pi: any): void {
 
   pi.on?.('session_start', (_event: unknown, ctx: any) => {
     clearClaudeBackgroundWidget();
+    clearActivityProvider();
     const cwd = ctx?.cwd ?? process.cwd();
+    const sessionId = currentSessionId(ctx);
     manager.reconcileOrphanedTasks(cwd);
+    if (typeof ctx?.cwd === 'string' && ctx.cwd.length > 0 && sessionId) disposeActivityProvider = registerSubagentActivityProvider(pi, manager, { cwd: ctx.cwd, sessionId });
     for (const warning of subagentSourceWarnings(cwd)) ctx?.ui?.notify?.(warning, 'warning');
     if (typeof ctx?.ui?.setWidget !== 'function') return;
     widgetCtx = ctx;
@@ -85,6 +92,7 @@ export default function subagentsExtension(pi: any): void {
   });
 
   pi.on?.('session_shutdown', () => {
+    clearActivityProvider();
     manager.cancelRunning('Pi session shutdown');
     clearClaudeBackgroundWidget();
   });

--- a/src/manager.ts
+++ b/src/manager.ts
@@ -268,6 +268,8 @@ type SendMessageInput = {
   session_id?: string;
 };
 
+type TaskUpdateListener = (task: SubagentTask) => void;
+
 type LaunchAttemptInput = {
   definition: SubagentDefinition;
   taskText: string;
@@ -296,12 +298,22 @@ export class SubagentManager {
   private runnerSettlements = new Map<string, Promise<void>>();
   private stopDispositions = new Map<string, StopDisposition>();
   private liveStates = new Map<string, LiveTaskState>();
+  private taskUpdateListeners = new Set<TaskUpdateListener>();
 
   constructor(
     private runner: SubagentRunner = sdkSubagentRunner,
     private history = new SubagentHistoryStore(),
     private onTerminalBackgroundTask?: (task: SubagentTask, cwd: string) => void,
   ) {}
+
+  listLiveTasks(cwd: string, sessionId: string): readonly SubagentTask[] {
+    return [...this.tasks.values()].filter((task) => this.taskCwds.get(task.id) === cwd && task.session_id === sessionId);
+  }
+
+  subscribeTaskUpdates(listener: TaskUpdateListener): () => void {
+    this.taskUpdateListeners.add(listener);
+    return () => this.taskUpdateListeners.delete(listener);
+  }
 
   listAgents(cwd: string, ctx: any = {}) {
     const config = readSubagentsConfig(cwd);
@@ -387,6 +399,7 @@ export class SubagentManager {
       task.mode = 'background';
       task.effective_mode = 'background';
       this.record(cwd, task, task.last_activity ?? 'running', true);
+      this.notifyTaskUpdate(id, undefined, true);
       changed.push(task);
     }
     return changed;
@@ -670,6 +683,7 @@ export class SubagentManager {
       task.pending_message_count = 0;
       task.undelivered_message_count = task.undelivered_message_count ?? 0;
       if (cwd) this.record(cwd, task, task.last_activity, true);
+      this.notifyTaskUpdate(id, undefined, true);
       return task;
     }
     if (task.status === 'stopping') return task;
@@ -1047,20 +1061,29 @@ export class SubagentManager {
   }
 
   private notifyTaskUpdate(taskId: string, onTaskUpdate: (() => void) | undefined, immediate = false): void {
-    if (!onTaskUpdate) return;
+    if (!onTaskUpdate && !this.taskUpdateListeners.size) return;
     const task = this.tasks.get(taskId);
-    if (!immediate && task && (task.status === 'stopping' || isTerminalStatus(task.status))) return;
+    if (!task) return;
+    if (!immediate && (task.status === 'stopping' || isTerminalStatus(task.status))) return;
+    const emit = () => {
+      const current = this.tasks.get(taskId);
+      if (!current) return;
+      for (const listener of [...this.taskUpdateListeners]) {
+        try { listener(current); } catch { /* observers must not break delegation */ }
+      }
+      onTaskUpdate?.();
+    };
     if (immediate) {
       const pending = this.pendingUpdates.get(taskId);
       if (pending) clearTimeout(pending);
       this.pendingUpdates.delete(taskId);
-      onTaskUpdate();
+      emit();
       return;
     }
     if (this.pendingUpdates.has(taskId)) return;
     const timer = setTimeout(() => {
       this.pendingUpdates.delete(taskId);
-      onTaskUpdate();
+      emit();
     }, ACTIVITY_UPDATE_FLUSH_MS);
     timer.unref?.();
     this.pendingUpdates.set(taskId, timer);

--- a/test/activity-provider.test.ts
+++ b/test/activity-provider.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import extension, { getSubagentActivityProvider } from '../index.js';
+import { registerSubagentActivityProvider } from '../src/activity-provider.js';
+import { installSubagentTestEnv } from './helpers/subagent-test-helpers.js';
+import type { SubagentRunner } from '../src/types.js';
+
+const { MockManager, instances } = vi.hoisted(() => {
+  const instances: any[] = [];
+  class MockManager {
+    static initialTasks: any[] = [];
+    readonly tasks = new Map<string, any>();
+    readonly listeners = new Set<() => void>();
+    listLiveTasksCalls = 0;
+    historyReads = 0;
+    constructor() { for (const task of MockManager.initialTasks) this.tasks.set(task.id, structuredClone(task)); MockManager.initialTasks = []; instances.push(this); }
+    listLiveTasks(cwd?: string, sessionId?: string) { this.listLiveTasksCalls += 1; return [...this.tasks.values()].filter((task) => (!cwd || task.cwd === cwd) && (!sessionId || task.session_id === sessionId)); }
+    subscribeTaskUpdates(listener: () => void) { this.listeners.add(listener); return () => this.listeners.delete(listener); }
+    listTasks() { this.historyReads += 1; return []; }
+    listSessionTasks() { return []; }
+    reconcileOrphanedTasks() { return []; }
+    cancelRunning() { return []; }
+    emit() { for (const listener of [...this.listeners]) listener(); }
+    update(id: string, patch: Record<string, unknown>) { Object.assign(this.tasks.get(id), patch); this.emit(); }
+  }
+  return { MockManager, instances };
+});
+vi.mock('../src/manager.js', () => ({ SubagentManager: MockManager }));
+type ActivityProvider = NonNullable<ReturnType<typeof getSubagentActivityProvider>>;
+const env = installSubagentTestEnv();
+
+function task(id: string, status = 'queued') {
+  return {
+    id, agent: 'analyst', mode: 'task', status,
+    task: 'PROMPT_CANARY', context: 'CONTEXT_CANARY', prompt: 'PROMPT_CANARY', system_prompt: 'SYSTEM_CANARY',
+    transcript: 'TRANSCRIPT_CANARY', output_preview: 'OUTPUT_CANARY', error: 'ERROR_CANARY', nested_session_path: '/SECRET_PATH_CANARY/session.jsonl',
+    cwd: 'test-cwd', session_id: 'test-session', parent_task_id: 'INFERRED_PARENT_CANARY',
+    created_at: '2026-01-01T00:00:00.000Z', started_at: '2026-01-01T00:00:01.000Z', last_activity_at: '2026-01-01T00:00:02.000Z',
+    model: 'provider/model', effort: 'high', model_source: 'profile', effort_source: 'definition',
+    usage: { input: 10, output: 4, cacheRead: 2, cacheWrite: 1, cost: 0.5, contextTokens: 14, turns: 2 },
+    live_activity: { trail: [], current: { kind: 'tool_running', label: 'LABEL_CANARY /SECRET_PATH_CANARY ARG_CANARY OUTPUT_CANARY', tool_names: ['read', 'bash'] } },
+  };
+}
+function makePi() {
+  const handlers = new Map<string, Function>();
+  const pi = { registerMessageRenderer: vi.fn(), registerShortcut: vi.fn(), registerCommand: vi.fn(), registerTool: vi.fn(), on: vi.fn((event: string, handler: Function) => handlers.set(event, handler)) };
+  return { pi, handlers };
+}
+function start(initialTasks: any[] = []): { provider: ActivityProvider; manager: any; pi: any } {
+  MockManager.initialTasks = initialTasks;
+  const { pi, handlers } = makePi();
+  extension(pi);
+  handlers.get('session_start')?.({}, { cwd: 'test-cwd', sessionId: 'test-session', ui: {} });
+  const manager = instances.at(-1)!;
+  const provider = getSubagentActivityProvider(pi);
+  if (!provider) throw new Error('provider was not registered');
+  return { provider, manager, pi };
+}
+
+describe('public subagent activity provider', () => {
+  beforeEach(() => { instances.length = 0; MockManager.initialTasks = []; });
+
+  it('is root-discoverable, manager-backed, safe, and immutable', () => {
+    const { provider, manager } = start([task('task-1')]);
+    const snapshot = provider.getSnapshot();
+    expect(snapshot).toMatchObject({ version: 1, revision: 0, tasks: [{ id: 'task-1', agent: 'analyst', mode: 'task', status: 'queued', model: 'provider/model', effort: 'high' }] });
+    expect(snapshot.tasks[0]).toMatchObject({ created_at: '2026-01-01T00:00:00.000Z', started_at: '2026-01-01T00:00:01.000Z', last_activity_at: '2026-01-01T00:00:02.000Z', model_source: 'profile', effort_source: 'definition', activity: { kind: 'tool_running', tool_names: ['read', 'bash'] } });
+    expect(snapshot.tasks[0]).toHaveProperty('usage.input', 10);
+    expect(JSON.stringify(snapshot)).not.toMatch(/CANARY/);
+    expect(Object.isFrozen(snapshot)).toBe(true); expect(Object.isFrozen(snapshot.tasks)).toBe(true); expect(Object.isFrozen(snapshot.tasks[0])).toBe(true);
+    expect(Object.isFrozen(snapshot.tasks[0]?.usage)).toBe(true); expect(Object.isFrozen(snapshot.tasks[0]?.activity)).toBe(true);
+    manager.tasks.set('unknown', { ...task('unknown'), model: 'bad model', effort: 'unknown', model_source: 'unknown', effort_source: 'unknown', usage: { input: 'bad', secret: 'SECRET_CANARY' }, live_activity: { current: { kind: 'unknown', tool_names: ['/SECRET_PATH_CANARY'] } } });
+    manager.emit();
+    expect(provider.getSnapshot().tasks.find((entry) => entry.id === 'unknown')).toMatchObject({ id: 'unknown' });
+    expect(JSON.stringify(provider.getSnapshot().tasks.find((entry) => entry.id === 'unknown'))).not.toMatch(/bad model|SECRET_CANARY|SECRET_PATH_CANARY/);
+    expect(manager.listLiveTasksCalls).toBe(2); expect(manager.historyReads).toBe(0); expect('cancel' in provider).toBe(false);
+  });
+
+  it('delivers synchronously with ordered revisions and idempotent unsubscribe', () => {
+    const { provider, manager } = start([task('task-1')]);
+    const received: any[] = []; const unsubscribe = provider.subscribe((snapshot) => received.push(snapshot));
+    expect(received).toHaveLength(1); expect(received[0]).toBe(provider.getSnapshot());
+    manager.update('task-1', { status: 'running', last_activity_at: '2026-01-01T00:00:03.000Z' });
+    manager.update('task-1', { status: 'completed', ended_at: '2026-01-01T00:00:04.000Z', live_activity: undefined });
+    expect(received.map((snapshot) => snapshot.tasks[0]?.status)).toEqual(['queued', 'running', 'completed']);
+    expect(received.map((snapshot) => snapshot.revision)).toEqual([0, 1, 2]);
+    expect(received.every((snapshot, index) => index === 0 || snapshot.revision > received[index - 1].revision)).toBe(true);
+    unsubscribe(); unsubscribe(); manager.update('task-1', { status: 'failed', error: 'late update' }); expect(received).toHaveLength(3);
+  });
+
+  it('keeps concurrent tasks independent, accepts only existing statuses, and ignores terminal activity', () => {
+    const { provider, manager } = start(['completed', 'failed', 'stopping', 'cancelled', 'interrupted', 'running', 'queued', 'waiting'].map((status) => task(status, status)));
+    const received: any[] = []; provider.subscribe((snapshot) => received.push(snapshot));
+    expect(received[0].tasks.map((entry: any) => entry.status)).toEqual(['completed', 'failed', 'stopping', 'cancelled', 'interrupted', 'running', 'queued']);
+    manager.update('running', { status: 'completed', ended_at: '2026-01-01T00:00:05.000Z' }); const beforeLateActivity = provider.getSnapshot();
+    manager.update('running', { live_activity: { current: { kind: 'tool_running', label: 'LATE_CANARY', tool_names: ['read'] } } });
+    expect(provider.getSnapshot()).toBe(beforeLateActivity); expect(received).toHaveLength(2); expect(JSON.stringify(provider.getSnapshot())).not.toContain('LATE_CANARY');
+    expect(provider.getSnapshot().tasks.find((entry) => entry.id === 'queued')?.status).toBe('queued'); expect(received.at(-1)?.tasks.find((entry: any) => entry.id === 'failed')?.status).toBe('failed');
+  });
+
+  it('keeps 100-task notification work bounded, lossless, monotonic, and history-free', () => {
+    const { provider, manager } = start(Array.from({ length: 100 }, (_, index) => task(`task-${index}`)));
+    const first: any[] = []; const second: any[] = []; provider.subscribe((snapshot) => first.push(snapshot)); provider.subscribe((snapshot) => second.push(snapshot));
+    for (let round = 0; round < 3; round += 1) for (let index = 0; index < 100; index += 1) manager.update(`task-${index}`, { status: round === 2 ? 'completed' : 'running', last_activity_at: `2026-01-01T00:0${round}:00.${String(index).padStart(3, '0')}Z` });
+    expect(first).toHaveLength(301); expect(second).toHaveLength(301); expect(first.at(-1)?.tasks).toHaveLength(100);
+    expect(new Set(first.at(-1)?.tasks.map((entry: any) => entry.status))).toEqual(new Set(['completed']));
+    expect(first.map((snapshot) => snapshot.revision)).toEqual(Array.from({ length: 301 }, (_, index) => index));
+    expect(manager.listLiveTasksCalls).toBe(first.length); expect(manager.historyReads).toBe(0);
+  });
+
+  it('filters by the authoritative scope, uses live tasks only, and unregisters cleanly', () => {
+    const { pi } = makePi(); const tasks = [
+      { ...task('old', 'completed'), cwd: 'old-cwd', session_id: 'old-session' },
+      { ...task('current', 'running'), cwd: 'current-cwd', session_id: 'current-session' },
+    ]; const calls: any[] = []; const listeners = new Set<Function>();
+    const manager = { listLiveTasks(cwd?: string, sessionId?: string) { calls.push([cwd, sessionId]); return cwd && sessionId ? tasks.filter((entry) => entry.cwd === cwd && entry.session_id === sessionId) : tasks; }, subscribeTaskUpdates(listener: Function) { listeners.add(listener); return () => listeners.delete(listener); } };
+    const dispose = (registerSubagentActivityProvider as any)(pi, manager, { cwd: 'current-cwd', sessionId: 'current-session' }); const provider = getSubagentActivityProvider(pi)!;
+    expect(provider.getSnapshot().tasks.map((entry) => entry.id)).toEqual(['current']); expect(calls[0]).toEqual(['current-cwd', 'current-session']);
+    dispose?.(); expect(getSubagentActivityProvider(pi)).toBeUndefined(); expect(listeners.size).toBe(0); dispose?.();
+  });
+
+  it('registers only for a live session and replaces/disposes on session and extension reload', () => {
+    const { pi, handlers } = makePi(); extension(pi); expect(getSubagentActivityProvider(pi)).toBeUndefined();
+    handlers.get('session_start')?.({}, { cwd: 'cwd-a', sessionId: 'session-a', ui: {} }); const first = getSubagentActivityProvider(pi)!; const firstManager = instances.at(-1)!; const oldUpdates: any[] = []; first.subscribe((snapshot) => oldUpdates.push(snapshot));
+    handlers.get('session_start')?.({}, { cwd: 'cwd-b', sessionId: 'session-b', ui: {} }); const second = getSubagentActivityProvider(pi)!;
+    expect(second).not.toBe(first); expect(firstManager.listeners.size).toBe(1); firstManager.emit(); expect(oldUpdates).toHaveLength(1);
+    extension(pi); expect(getSubagentActivityProvider(pi)).toBeUndefined(); expect(instances.at(-1)!.listeners.size).toBe(0);
+    handlers.get('session_start')?.({}, { cwd: 'cwd-c', sessionId: 'session-c', ui: {} }); expect(getSubagentActivityProvider(pi)).not.toBeUndefined();
+    handlers.get('session_shutdown')?.(); expect(getSubagentActivityProvider(pi)).toBeUndefined();
+  });
+
+  it('forwards real manager lifecycle events through the public seam', async () => {
+    const { SubagentManager: RealManager } = await vi.importActual<typeof import('../src/manager.js')>('../src/manager.js');
+    for (const name of ['completed', 'failed', 'cancelled', 'interrupted']) env.writeAgent(name);
+    const runner: SubagentRunner = async ({ definition, onActivity, signal }) => {
+      onActivity?.({ message: 'activity', live_activity: { trail: [], current: { kind: 'tool_running', label: 'safe activity', tool_names: ['read'] } } });
+      if (definition.name === 'completed') return { result: 'done', model: 'mock/model' };
+      if (definition.name === 'failed') throw new Error('failed');
+      return await new Promise((_resolve, reject) => signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true }));
+    };
+    const manager = new RealManager(runner); const pi = makePi().pi;
+    const dispose = (registerSubagentActivityProvider as any)(pi, manager, { cwd: env.tmp, sessionId: 'session-a' }); const provider = getSubagentActivityProvider(pi)!; const seen: any[] = [];
+    provider.subscribe((snapshot) => seen.push(snapshot)); const ctx = { cwd: env.tmp, sessionId: 'session-a' };
+    await manager.run({ agent: 'completed', task: 'done', mode: 'task' }, ctx); await manager.run({ agent: 'failed', task: 'fail', mode: 'task' }, ctx);
+    const cancelled = await manager.run({ agent: 'cancelled', task: 'cancel', mode: 'background' }, ctx); await vi.waitFor(() => expect(manager.getTask(cancelled.task_ids[0]!)?.status).toBe('running')); manager.cancel(cancelled.task_ids[0]!, 'user request');
+    const interrupted = await manager.run({ agent: 'interrupted', task: 'interrupt', mode: 'background' }, ctx); await vi.waitFor(() => expect(manager.getTask(interrupted.task_ids[0]!)?.status).toBe('running')); manager.cancel(interrupted.task_ids[0]!, 'Pi session shutdown');
+    await vi.waitFor(() => expect(manager.getTask(interrupted.task_ids[0]!)?.status).toBe('interrupted'));
+    const statuses = new Set(seen.flatMap((snapshot) => snapshot.tasks.map((entry: any) => entry.status)));
+    expect(statuses).toEqual(new Set(['queued', 'running', 'stopping', 'completed', 'failed', 'cancelled', 'interrupted']));
+    expect(seen.some((snapshot) => snapshot.tasks.some((entry: any) => entry.activity?.kind === 'tool_running'))).toBe(true); expect(seen.at(-1)?.revision).toBeGreaterThan(0); dispose?.();
+  });
+});

--- a/test/activity-provider.test.ts
+++ b/test/activity-provider.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import extension, { getSubagentActivityProvider } from '../index.js';
+import extension, { getSubagentActivityProvider, watchSubagentActivityProvider } from '../index.js';
 import { registerSubagentActivityProvider } from '../src/activity-provider.js';
 import { installSubagentTestEnv } from './helpers/subagent-test-helpers.js';
 import type { SubagentRunner } from '../src/types.js';
@@ -128,7 +128,25 @@ describe('public subagent activity provider', () => {
     handlers.get('session_shutdown')?.(); expect(getSubagentActivityProvider(pi)).toBeUndefined();
   });
 
-  it('forwards real manager lifecycle events through the public seam', async () => {
+  it('discovers a provider registered after a root consumer subscribes without stale replacement events', () => {
+  const { pi } = makePi(); const received: Array<ActivityProvider | undefined> = []; const manager = { listLiveTasks: () => [], subscribeTaskUpdates: () => () => undefined };
+  const unsubscribe = watchSubagentActivityProvider(pi, (provider) => received.push(provider)); expect(received).toEqual([undefined]);
+  const disposeFirst = (registerSubagentActivityProvider as any)(pi, manager, { cwd: 'cwd-a', sessionId: 'session-a' }); const first = getSubagentActivityProvider(pi)!; expect(received).toEqual([undefined, first]);
+  const disposeSecond = (registerSubagentActivityProvider as any)(pi, manager, { cwd: 'cwd-b', sessionId: 'session-b' }); const second = getSubagentActivityProvider(pi)!; expect(received).toEqual([undefined, first, second]);
+  disposeFirst?.(); expect(received).toEqual([undefined, first, second]); disposeSecond?.(); expect(received).toEqual([undefined, first, second, undefined]); disposeSecond?.(); unsubscribe?.(); unsubscribe?.();
+  (registerSubagentActivityProvider as any)(pi, manager, { cwd: 'cwd-c', sessionId: 'session-c' }); expect(received).toEqual([undefined, first, second, undefined]);
+ });
+
+ it('isolates discovery listener failures and cleans up Gentle-first reload and shutdown discovery', () => {
+  const { pi, handlers } = makePi(); const received: Array<ActivityProvider | undefined> = []; const throwing = vi.fn(() => { throw new Error('observer failure'); });
+  const stopThrowing = watchSubagentActivityProvider(pi, throwing); const stop = watchSubagentActivityProvider(pi, (provider) => received.push(provider)); expect(received).toEqual([undefined]);
+  extension(pi); handlers.get('session_start')?.({}, { cwd: 'cwd-a', sessionId: 'session-a', ui: {} }); const first = getSubagentActivityProvider(pi)!; const firstManager = instances.at(-1)!;
+  expect(received).toEqual([undefined, first]); extension(pi); expect(getSubagentActivityProvider(pi)).toBeUndefined(); expect(firstManager.listeners.size).toBe(0); expect(received.at(-1)).toBeUndefined();
+  handlers.get('session_start')?.({}, { cwd: 'cwd-b', sessionId: 'session-b', ui: {} }); const second = getSubagentActivityProvider(pi)!; expect(received.at(-1)).toBe(second); handlers.get('session_shutdown')?.();
+  expect(getSubagentActivityProvider(pi)).toBeUndefined(); expect(received.at(-1)).toBeUndefined(); expect(throwing).toHaveBeenCalled(); stop?.(); stop?.(); stopThrowing?.();
+ });
+
+ it('forwards real manager lifecycle events through the public seam', async () => {
     const { SubagentManager: RealManager } = await vi.importActual<typeof import('../src/manager.js')>('../src/manager.js');
     for (const name of ['completed', 'failed', 'cancelled', 'interrupted']) env.writeAgent(name);
     const runner: SubagentRunner = async ({ definition, onActivity, signal }) => {

--- a/test/activity-provider.test.ts
+++ b/test/activity-provider.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import extension, { getSubagentActivityProvider, watchSubagentActivityProvider } from '../index.js';
+import extension, { getSubagentActivityProvider, SUBAGENT_ACTIVITY_PROVIDER_CHANGED_CHANNEL, SUBAGENT_ACTIVITY_PROVIDER_REQUEST_CHANNEL, watchSubagentActivityProvider } from '../index.js';
 import { registerSubagentActivityProvider } from '../src/activity-provider.js';
 import { installSubagentTestEnv } from './helpers/subagent-test-helpers.js';
 import type { SubagentRunner } from '../src/types.js';
@@ -40,9 +40,17 @@ function task(id: string, status = 'queued') {
     live_activity: { trail: [], current: { kind: 'tool_running', label: 'LABEL_CANARY /SECRET_PATH_CANARY ARG_CANARY OUTPUT_CANARY', tool_names: ['read', 'bash'] } },
   };
 }
-function makePi() {
+function makeEventBus() {
+  const listeners = new Map<string, Set<Function>>(); const emissions: Array<[string, unknown]> = [];
+  const bus = {
+    on: vi.fn((channel: string, handler: Function) => { const handlers = listeners.get(channel) ?? new Set<Function>(); handlers.add(handler); listeners.set(channel, handlers); return () => handlers.delete(handler); }),
+    emit: vi.fn((channel: string, data: unknown) => { emissions.push([channel, data]); for (const handler of [...(listeners.get(channel) ?? [])]) handler(data); }),
+  };
+  return { bus, listeners, emissions };
+}
+function makePi(events?: any) {
   const handlers = new Map<string, Function>();
-  const pi = { registerMessageRenderer: vi.fn(), registerShortcut: vi.fn(), registerCommand: vi.fn(), registerTool: vi.fn(), on: vi.fn((event: string, handler: Function) => handlers.set(event, handler)) };
+  const pi = { registerMessageRenderer: vi.fn(), registerShortcut: vi.fn(), registerCommand: vi.fn(), registerTool: vi.fn(), on: vi.fn((event: string, handler: Function) => handlers.set(event, handler)), ...(events ? { events } : {}) };
   return { pi, handlers };
 }
 function start(initialTasks: any[] = []): { provider: ActivityProvider; manager: any; pi: any } {
@@ -145,6 +153,24 @@ describe('public subagent activity provider', () => {
   handlers.get('session_start')?.({}, { cwd: 'cwd-b', sessionId: 'session-b', ui: {} }); const second = getSubagentActivityProvider(pi)!; expect(received.at(-1)).toBe(second); handlers.get('session_shutdown')?.();
   expect(getSubagentActivityProvider(pi)).toBeUndefined(); expect(received.at(-1)).toBeUndefined(); expect(throwing).toHaveBeenCalled(); stop?.(); stop?.(); stopThrowing?.();
  });
+
+ it('discovers across distinct API proxies when the consumer loads first, then replaces, disposes, reloads, and shuts down', () => {
+    const { bus, listeners, emissions } = makeEventBus(); const consumer = makePi(bus); const providerApi = makePi(bus); const seen: Array<ActivityProvider | undefined> = [];
+    const stop = watchSubagentActivityProvider(consumer.pi, (provider) => seen.push(provider)); expect(seen).toEqual([undefined]); expect(emissions).toEqual([[SUBAGENT_ACTIVITY_PROVIDER_REQUEST_CHANNEL, undefined]]);
+    extension(providerApi.pi); providerApi.handlers.get('session_start')?.({}, { cwd: 'cwd-a', sessionId: 'session-a', ui: {} }); const first = getSubagentActivityProvider(providerApi.pi)!;
+    expect(seen).toEqual([undefined, first]); expect(emissions.filter(([channel]) => channel === SUBAGENT_ACTIVITY_PROVIDER_CHANGED_CHANNEL)).toHaveLength(1);
+    providerApi.handlers.get('session_start')?.({}, { cwd: 'cwd-b', sessionId: 'session-b', ui: {} }); const second = getSubagentActivityProvider(providerApi.pi)!;
+    expect(second).not.toBe(first); expect(seen).toEqual([undefined, first, second]); providerApi.handlers.get('session_shutdown')?.(); expect(seen.at(-1)).toBeUndefined();
+    stop?.(); const beforeReload = seen.length; extension(providerApi.pi); expect(seen).toHaveLength(beforeReload); expect(listeners.get(SUBAGENT_ACTIVITY_PROVIDER_REQUEST_CHANNEL)?.size).toBe(1);
+  });
+
+  it('discovers a provider loaded first through a request without duplicate consumer emissions', () => {
+    const { bus, emissions } = makeEventBus(); const providerApi = makePi(bus); const consumer = makePi(bus); extension(providerApi.pi);
+    providerApi.handlers.get('session_start')?.({}, { cwd: 'cwd-a', sessionId: 'session-a', ui: {} }); const provider = getSubagentActivityProvider(providerApi.pi)!; const seen: Array<ActivityProvider | undefined> = [];
+    const stop = watchSubagentActivityProvider(consumer.pi, (current) => seen.push(current)); expect(seen).toEqual([undefined, provider]);
+    expect(emissions.filter(([channel]) => channel === SUBAGENT_ACTIVITY_PROVIDER_REQUEST_CHANNEL)).toHaveLength(1); expect(seen.filter((current) => current === provider)).toHaveLength(1);
+    stop?.(); providerApi.handlers.get('session_shutdown')?.(); expect(seen).toEqual([undefined, provider]);
+  });
 
  it('forwards real manager lifecycle events through the public seam', async () => {
     const { SubagentManager: RealManager } = await vi.importActual<typeof import('../src/manager.js')>('../src/manager.js');


### PR DESCRIPTION
Closes #19

## Summary

- expose a versioned, read-only activity provider from the package root
- project immutable, revisioned snapshots from the existing `SubagentManager`
- publish provider availability over documented, versioned `pi.events` channels for cross-extension discovery
- preserve root getter/watcher APIs for same-module consumers
- scope activity to the current Pi session/cwd and clean up providers on replacement or shutdown
- publish only bounded safe metadata while preserving existing tools, history, widgets, and notifications

## Changes

| File | Change |
|---|---|
| `src/activity-provider.ts` | Add provider contract, safe projection, revisions, subscriptions, disposal, and event-bus discovery transport. |
| `src/manager.ts` | Expose filtered live-task reads and manager update subscriptions without adding a second store. |
| `src/extension/subagents-extension.ts` | Register the provider on session start, publish changes, answer discovery requests, and clean up on shutdown/replacement. |
| `index.ts` | Export provider APIs, consumer types, and versioned event channel constants. |
| `test/activity-provider.test.ts` | Cover real lifecycle transitions, privacy, distinct extension proxies, both load orders, replacement, session scope, cleanup, concurrency, and 100-task behavior. |
| `README.md` | Document same-module and cross-extension consumption plus safety guarantees. |

## Public contract

Same-module consumers may use `watchSubagentActivityProvider(pi, listener)` or `getSubagentActivityProvider(pi)`.

Separate Pi extensions use the documented shared event bus:

1. subscribe to the versioned `changed` channel;
2. emit the versioned `request` channel;
3. receive the current provider or `undefined`;
4. continue receiving registration, replacement, and disposal updates.

This works when either extension loads first because `pi.events` is shared across distinct ExtensionAPI proxies. The provider returns full immutable snapshots, emits strictly increasing revisions only when projected data changes, and exposes no task-control or history-replay methods.

## Test plan

- [x] focused activity-provider tests — 11 passed
- [x] related manager/subagent tests — 66 passed
- [x] `npm test` — 299 passed across 29 files
- [x] `npm run typecheck`
- [x] `npm run verify:package`
- [x] `npm pack --dry-run`
- [x] `npm run check`
- [x] `git diff --check`

## Scope

This PR adds no UI, task controls, scheduler, database migration, history replay, polling, inferred states, or second task store. Downstream consumers such as [Gentle Pi #430](https://github.com/Gentleman-Programming/gentle-pi/issues/430) remain separate.

Review budget: 394 changed lines / 400.

## Audit note

`npm audit` reports the repository's existing 10 high-severity findings. `package.json` and `package-lock.json` are unchanged by this PR.
